### PR TITLE
Fix error when the callbacks array changes size while processing an event.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -74,13 +74,21 @@ WildEmitter.prototype.emit = function (event) {
 
     if (callbacks) {
         for (i = 0, len = callbacks.length; i < len; ++i) {
-            callbacks[i].apply(this, args);
+            if (callbacks[i]) {
+                callbacks[i].apply(this, args);
+            } else {
+                break;
+            }
         }
     }
 
     if (specialCallbacks) {
         for (i = 0, len = specialCallbacks.length; i < len; ++i) {
-            specialCallbacks[i].apply(this, [event].concat(args));
+            if (specialCallbacks[i]) {
+                specialCallbacks[i].apply(this, [event].concat(args));
+            } else {
+                break;
+            }
         }
     }
 

--- a/wildemitter-bare.js
+++ b/wildemitter-bare.js
@@ -74,13 +74,21 @@ WildEmitter.prototype.emit = function (event) {
 
     if (callbacks) {
         for (i = 0, len = callbacks.length; i < len; ++i) {
-            callbacks[i].apply(this, args);
+            if (callbacks[i]) {
+                callbacks[i].apply(this, args);
+            } else {
+                break;
+            }
         }
     }
 
     if (specialCallbacks) {
         for (i = 0, len = specialCallbacks.length; i < len; ++i) {
-            specialCallbacks[i].apply(this, [event].concat(args));
+            if (specialCallbacks[i]) {
+                specialCallbacks[i].apply(this, [event].concat(args));
+            } else {
+                break;
+            }
         }
     }
 

--- a/wildemitter.js
+++ b/wildemitter.js
@@ -95,13 +95,21 @@ WildEmitter.prototype.emit = function (event) {
 
     if (callbacks) {
         for (i = 0, len = callbacks.length; i < len; ++i) {
-            callbacks[i].apply(this, args);
+            if (callbacks[i]) {
+                callbacks[i].apply(this, args);
+            } else {
+                break;
+            }
         }
     }
 
     if (specialCallbacks) {
         for (i = 0, len = specialCallbacks.length; i < len; ++i) {
-            specialCallbacks[i].apply(this, [event].concat(args));
+            if (specialCallbacks[i]) {
+                specialCallbacks[i].apply(this, [event].concat(args));
+            } else {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Making an event handler release groups which affect the event being processed, kind of broke things.

(Needed to make things work for stanza.io with reconnecting and not duplicating event handlers)
