### PR TITLE
Ensure wildemitter callbacks object gets it's keys removed when callback array is empty.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -62,6 +62,9 @@ WildEmitter.prototype.off = function (event, fn) {
     // remove specific handler
     i = callbacks.indexOf(fn);
     callbacks.splice(i, 1);
+    if (callbacks.length === 0) {
+        delete this.callbacks[event];
+    }
     return this;
 };
 

--- a/test.js
+++ b/test.js
@@ -91,6 +91,7 @@ exports['Test once for multiple functions'] = function (test) {
 
 exports['Test on and off'] = function (test) {
     var count, cb1, cb2;
+    var orange = new Fruit('orange');
 
     count = 0;
     cb1 = function () {
@@ -112,6 +113,12 @@ exports['Test on and off'] = function (test) {
 
     orange.emit('test2');
     test.equal(count, 2);
+
+    orange.off('test2', cb2);
+
+    //ensure callbacks array is removed entirely
+    test.ok(orange.callbacks.test == null);
+    test.ok(orange.callbacks.test2 == null);
 
     test.done();
 };

--- a/wildemitter-bare.js
+++ b/wildemitter-bare.js
@@ -62,6 +62,9 @@ WildEmitter.prototype.off = function (event, fn) {
     // remove specific handler
     i = callbacks.indexOf(fn);
     callbacks.splice(i, 1);
+    if (callbacks.length === 0) {
+        delete this.callbacks[event];
+    }
     return this;
 };
 

--- a/wildemitter.js
+++ b/wildemitter.js
@@ -83,6 +83,9 @@ WildEmitter.prototype.off = function (event, fn) {
     // remove specific handler
     i = callbacks.indexOf(fn);
     callbacks.splice(i, 1);
+    if (callbacks.length === 0) {
+        delete this.callbacks[event];
+    }
     return this;
 };
 


### PR DESCRIPTION
The lack of cleanup of the object means that iterating the wildcard gets slow if you use once a lot.