### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Written by [@HenrikJoreteg](http://twitter.com/henrikjoreteg) inspired by TJ's e
 
 Contributors: https://github.com/HenrikJoreteg/wildemitter/graphs/contributors
 
-##License
+## License
 MIT
 
 If you like this follow [@HenrikJoreteg](http://twitter.com/henrikjoreteg) on twitter.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
