### PR TITLE
Fixed issue where removing event handler which wasn't added was removing all event's handlers except of the last one.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -67,9 +67,11 @@ WildEmitter.mixin = function (constructor) {
 
         // remove specific handler
         i = callbacks.indexOf(fn);
-        callbacks.splice(i, 1);
-        if (callbacks.length === 0) {
-            delete this.callbacks[event];
+        if (i !== -1) {
+            callbacks.splice(i, 1);
+            if (callbacks.length === 0) {
+                delete this.callbacks[event];
+            }
         }
         return this;
     };


### PR DESCRIPTION
@HenrikJoreteg I've encountered on a case in my code where handler was being removed before it was added.
It took a while to track down the issue but in the end, it turned out if there are multiple handles attached and if we want to remove a handler which wasn't added (so indexOf would return -1) then all event handlers would be removed except of the last one in the array.

> a = [1,2,3]
> i = a.indexOf(10)
> a.splice(i, 1)
> // result = a = [3]